### PR TITLE
Adjustment to type 14 sub container

### DIFF
--- a/ContainerReader/Program.cs
+++ b/ContainerReader/Program.cs
@@ -11,7 +11,7 @@ namespace ContainerReader
     {
         static void Main(string[] args)
         {
-            if(args.Length != 1)
+            if (args.Length != 1)
             {
                 Console.WriteLine("ContainerReader\nA program that prints infomation about Windows Containers.index files, used to store metadata (such as the package family name, guid, and filename) about configuration/save game files for UWP apps and games.\nContainer \"filenames\" are actually directories, as they can have more than one file inside of them.\nUsage: ContainerReader containers.index\nNOTE: Doesn't, at the current time, handle all forms of containers.index. Will add support, but most are supported.");
                 return;
@@ -116,13 +116,8 @@ namespace ContainerReader
 
                             for (int y = 0; y < subNumFiles; y++)
                             {
-                                string subfileName = BinaryReaderHelper.ReadUnicodeString(subReader);
-
-                                // Ignore all the white space of the block
-                                while (subReader.ReadByte() == 0x0) { }
-
-                                // Go back to a position after reading a non-empty byte
-                                subReader.BaseStream.Position--;
+                                // subFileName has a fixed length
+                                string subfileName = BinaryReaderHelper.ReadUnicodeString(subReader, 0x40);
 
                                 // The sub guid folder that the files reside in
                                 byte[] subGuid1 = subReader.ReadBytes(4);


### PR DESCRIPTION
When working with my save files for Forza Horizon 4, I found that the call to `ReadUnicodeString` on line 119 did not provide a length, preventing a successful build. Additionally, even after providing some amount of length, reading until I hit a non-0x00 byte on line 122 did not work when the first byte of the GUID (as written in the file sequentially) was 0x00.

After some back and forth, I determined that the name segment had a fixed length of 0x80 (or technically, a Unicode string of length 0x40).

Can you verify that these changes still work against your We Happy Few saves?

As an aside, Visual Studio made a few minor formatting changes.